### PR TITLE
Add make_tool API and BYOK environment variable support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            cmake_generator: "Unix Makefiles"
+          - os: windows-latest
+            cmake_generator: "Visual Studio 17 2022"
+          - os: macos-latest
+            cmake_generator: "Unix Makefiles"
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure CMake
+        run: cmake -B build -G "${{ matrix.cmake_generator }}" -DCMAKE_BUILD_TYPE=Release -DCOPILOT_BUILD_TESTS=ON
+
+      - name: Build
+        run: cmake --build build --config Release
+
+      - name: Run Unit Tests
+        run: ctest --test-dir build -C Release -E "^E2ETest\." --output-on-failure
+        env:
+          COPILOT_SDK_CPP_SKIP_E2E: 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+tests/byok.env
+tests/logs/
 build*/
 cmake-build*/
 out*/

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -18,8 +18,17 @@ json build_session_create_request(const SessionConfig& config)
 {
     json request;
 
+    // Model: explicit > env (if auto_byok_from_env) > none
     if (config.model.has_value())
+    {
         request["model"] = *config.model;
+    }
+    else if (config.auto_byok_from_env)
+    {
+        if (auto env_model = ProviderConfig::model_from_env())
+            request["model"] = *env_model;
+    }
+
     if (config.session_id.has_value())
         request["sessionId"] = *config.session_id;
     if (config.on_permission_request.has_value())
@@ -57,8 +66,18 @@ json build_session_create_request(const SessionConfig& config)
         request["excludedTools"] = *config.excluded_tools;
     if (config.streaming)
         request["streaming"] = config.streaming;
+
+    // Provider: explicit > env (if auto_byok_from_env) > none
     if (config.provider.has_value())
+    {
         request["provider"] = *config.provider;
+    }
+    else if (config.auto_byok_from_env)
+    {
+        if (auto env_provider = ProviderConfig::from_env())
+            request["provider"] = *env_provider;
+    }
+
     if (config.mcp_servers.has_value())
         request["mcpServers"] = *config.mcp_servers;
     if (config.custom_agents.has_value())
@@ -96,8 +115,18 @@ json build_session_resume_request(const std::string& session_id, const ResumeSes
     }
     if (config.streaming)
         request["streaming"] = config.streaming;
+
+    // Provider: explicit > env (if auto_byok_from_env) > none
     if (config.provider.has_value())
+    {
         request["provider"] = *config.provider;
+    }
+    else if (config.auto_byok_from_env)
+    {
+        if (auto env_provider = ProviderConfig::from_env())
+            request["provider"] = *env_provider;
+    }
+
     if (config.mcp_servers.has_value())
         request["mcpServers"] = *config.mcp_servers;
     if (config.custom_agents.has_value())

--- a/tests/repro/.gitignore
+++ b/tests/repro/.gitignore
@@ -1,0 +1,4 @@
+byok.env
+build/
+*.exe
+*.obj

--- a/tests/repro/CMakeLists.txt
+++ b/tests/repro/CMakeLists.txt
@@ -1,0 +1,57 @@
+# Standalone repro for ResumeSessionWithTools issue
+# This is a completely independent project - does NOT include the SDK as subdirectory
+#
+# Prerequisites:
+#   Build the SDK first:
+#     cd ../..
+#     cmake -B build -G "Visual Studio 17 2022" -A x64
+#     cmake --build build --config Release
+#
+# Build this repro:
+#   cd tests/repro
+#   cmake -B build -G "Visual Studio 17 2022" -A x64
+#   cmake --build build --config Release
+#
+# Run:
+#   build\Release\repro_resume_with_tools.exe
+
+cmake_minimum_required(VERSION 3.20)
+project(repro_resume_with_tools)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Paths to pre-built SDK
+set(SDK_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../..")
+set(SDK_INCLUDE "${SDK_ROOT}/include")
+set(SDK_LIB_DIR "${SDK_ROOT}/build/Release")
+set(SDK_BUILD_DIR "${SDK_ROOT}/build")
+
+# Check SDK was built
+if(NOT EXISTS "${SDK_LIB_DIR}/copilot_sdk_cpp.lib")
+    message(FATAL_ERROR
+        "SDK not built. Please build the SDK first:\n"
+        "  cd ${SDK_ROOT}\n"
+        "  cmake -B build && cmake --build build --config Release")
+endif()
+
+# Fetch nlohmann/json (same as SDK does)
+include(FetchContent)
+FetchContent_Declare(
+    nlohmann_json
+    GIT_REPOSITORY https://github.com/nlohmann/json.git
+    GIT_TAG v3.11.3
+)
+set(JSON_BuildTests OFF CACHE INTERNAL "")
+FetchContent_MakeAvailable(nlohmann_json)
+
+add_executable(repro_resume_with_tools repro_resume_with_tools.cpp)
+
+target_include_directories(repro_resume_with_tools PRIVATE "${SDK_INCLUDE}")
+target_link_libraries(repro_resume_with_tools PRIVATE nlohmann_json::nlohmann_json)
+target_link_libraries(repro_resume_with_tools PRIVATE "${SDK_LIB_DIR}/copilot_sdk_cpp.lib")
+
+# Windows socket library
+if(WIN32)
+    target_link_libraries(repro_resume_with_tools PRIVATE ws2_32)
+endif()

--- a/tests/repro/README.md
+++ b/tests/repro/README.md
@@ -1,0 +1,49 @@
+# Repro: ResumeSessionWithTools BYOK Issue
+
+Standalone reproduction of the issue where resuming a session with new tools
+fails when using BYOK (Bring Your Own Key) with OpenAI, but works with Copilot auth.
+
+## Issue
+
+When using BYOK with OpenAI:
+- Resume session with new tool registration
+- Ask AI to use the new tool
+- **Tool is never invoked**
+
+With Copilot auth: **PASS** (20s)
+With BYOK/OpenAI: **FAIL** (tool never called)
+
+## Build
+
+```cmd
+cd tests/repro
+cmake -B build -G "Visual Studio 17 2022" -A x64
+cmake --build build --config Release
+```
+
+## Run
+
+Without BYOK (uses Copilot auth):
+```cmd
+build\Release\repro_resume_with_tools.exe
+```
+
+With BYOK:
+```cmd
+copy byok.env.example byok.env
+# Edit byok.env with your OpenAI credentials
+build\Release\repro_resume_with_tools.exe
+```
+
+## Expected Output
+
+With Copilot:
+```
+[!] Tool invoked with key: ALPHA
+[PASS] Tool was invoked correctly!
+```
+
+With BYOK/OpenAI:
+```
+[FAIL] Tool was NOT invoked - this is the BYOK/OpenAI limitation
+```

--- a/tests/repro/byok.env.example
+++ b/tests/repro/byok.env.example
@@ -1,0 +1,7 @@
+# Copy this file to byok.env and fill in your API credentials
+# This file is gitignored for security
+
+COPILOT_SDK_BYOK_API_KEY=sk-your-api-key-here
+COPILOT_SDK_BYOK_BASE_URL=https://api.openai.com/v1
+COPILOT_SDK_BYOK_PROVIDER_TYPE=openai
+COPILOT_SDK_BYOK_MODEL=gpt-4.1

--- a/tests/repro/repro_resume_with_tools.cpp
+++ b/tests/repro/repro_resume_with_tools.cpp
@@ -1,0 +1,177 @@
+// Repro: ResumeSessionWithTools fails with BYOK (OpenAI) but passes with Copilot
+//
+// Issue: When using BYOK with OpenAI, resuming a session with new tools doesn't work.
+// The AI never invokes the tool registered during resume.
+//
+// With Copilot auth: PASS (20s)
+// With BYOK/OpenAI: FAIL (tool never called)
+//
+// Build:
+//   cl /EHsc /std:c++20 /I../../include repro_resume_with_tools.cpp /link /LIBPATH:../../build/Release copilot_sdk_cpp.lib
+//
+// Or use CMake (see CMakeLists.txt)
+
+#include <copilot/copilot.hpp>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <string>
+
+using namespace copilot;
+
+// Load byok.env if present
+void load_byok_env()
+{
+    std::filesystem::path env_file = std::filesystem::path(__FILE__).parent_path() / "byok.env";
+    if (!std::filesystem::exists(env_file))
+    {
+        std::cout << "[REPRO] No byok.env found, using Copilot auth\n";
+        return;
+    }
+
+    std::ifstream file(env_file);
+    std::string line;
+    while (std::getline(file, line))
+    {
+        if (line.empty() || line[0] == '#')
+            continue;
+        auto pos = line.find('=');
+        if (pos == std::string::npos)
+            continue;
+        std::string key = line.substr(0, pos);
+        std::string value = line.substr(pos + 1);
+#ifdef _WIN32
+        _putenv_s(key.c_str(), value.c_str());
+#else
+        setenv(key.c_str(), value.c_str(), 1);
+#endif
+    }
+    std::cout << "[REPRO] Loaded BYOK config from byok.env\n";
+}
+
+int main()
+{
+    load_byok_env();
+
+    std::cout << "\n=== Repro: ResumeSessionWithTools ===\n\n";
+
+    // Create client
+    ClientOptions opts;
+    auto client = std::make_unique<Client>(opts);
+    client->start().get();
+    std::cout << "[1] Client started\n";
+
+    // Create session config with BYOK if available
+    SessionConfig config;
+    config.auto_byok_from_env = true;
+
+    // Create initial session (no tools)
+    auto session1 = client->create_session(config).get();
+    std::string session_id = session1->session_id();
+    std::cout << "[2] Created session: " << session_id << "\n";
+
+    // Wait for first message
+    std::atomic<bool> idle{false};
+    std::mutex mtx;
+    std::condition_variable cv;
+
+    session1->on([&](const SessionEvent& event) {
+        if (event.type == SessionEventType::SessionIdle)
+        {
+            idle = true;
+            cv.notify_one();
+        }
+    });
+
+    MessageOptions msg_opts;
+    msg_opts.prompt = "Say hello";
+    session1->send(msg_opts).get();
+    std::cout << "[3] Sent initial message\n";
+
+    {
+        std::unique_lock<std::mutex> lock(mtx);
+        cv.wait_for(lock, std::chrono::seconds(30), [&] { return idle.load(); });
+    }
+    std::cout << "[4] Session idle after first message\n";
+
+    // Stop client (don't destroy session)
+    client->stop().get();
+    std::cout << "[5] Client stopped\n";
+
+    // Restart client
+    client = std::make_unique<Client>(opts);
+    client->start().get();
+    std::cout << "[6] Client restarted\n";
+
+    // Define tool for resume
+    std::atomic<bool> tool_called{false};
+    std::string received_key;
+
+    Tool secret_tool;
+    secret_tool.name = "get_secret";
+    secret_tool.description = "Returns a secret value";
+    secret_tool.parameters_schema = json{
+        {"type", "object"},
+        {"properties", {{"key", {{"type", "string"}}}}},
+        {"required", {"key"}}};
+    secret_tool.handler = [&](const ToolInvocation& inv) -> ToolResultObject {
+        tool_called = true;
+        received_key = inv.arguments.value()["key"].get<std::string>();
+        std::cout << "[!] Tool invoked with key: " << received_key << "\n";
+
+        ToolResultObject result;
+        result.text_result_for_llm = "SECRET_VALUE_12345";
+        result.result_type = "success";
+        return result;
+    };
+
+    // Resume session WITH the new tool
+    ResumeSessionConfig resume_config;
+    resume_config.auto_byok_from_env = true;
+    resume_config.tools = {secret_tool};
+
+    auto session2 = client->resume_session(session_id, resume_config).get();
+    std::cout << "[7] Resumed session with tool\n";
+
+    // Reset for second wait
+    idle = false;
+
+    session2->on([&](const SessionEvent& event) {
+        if (event.type == SessionEventType::SessionIdle)
+        {
+            idle = true;
+            cv.notify_one();
+        }
+    });
+
+    // Ask AI to use the tool
+    msg_opts.prompt = "Use the get_secret tool with key 'ALPHA' and tell me the result.";
+    session2->send(msg_opts).get();
+    std::cout << "[8] Sent message asking to use tool\n";
+
+    {
+        std::unique_lock<std::mutex> lock(mtx);
+        cv.wait_for(lock, std::chrono::seconds(60), [&] { return idle.load(); });
+    }
+
+    // Check results
+    std::cout << "\n=== Results ===\n";
+    std::cout << "Tool called: " << (tool_called ? "YES" : "NO") << "\n";
+    std::cout << "Received key: " << (received_key.empty() ? "(empty)" : received_key) << "\n";
+
+    if (tool_called && received_key == "ALPHA")
+    {
+        std::cout << "\n[PASS] Tool was invoked correctly!\n";
+        return 0;
+    }
+    else
+    {
+        std::cout << "\n[FAIL] Tool was NOT invoked - this is the BYOK/OpenAI limitation\n";
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary

- Add `make_tool()`: Type-safe tool creation from lambdas with automatic JSON schema generation and proper `std::optional` parameter support
- Add BYOK (Bring Your Own Key): Load API credentials from environment variables (`COPILOT_SDK_BYOK_API_KEY`, etc.) via `auto_byok_from_env` flag in SessionConfig
- Add `default_session_config()` and `default_resume_config()` test helpers
- Add verbose test descriptions for all E2E tests
- Skip resume-with-tools tests when BYOK is active (known limitation)
- Add standalone repro for ResumeSessionWithTools BYOK issue
- Fix missing `<cstdlib>` include for `std::getenv`
- Fix `std::optional` parameter handling in `make_tool` schema generation