### PR TITLE
fix: update SDK protocol version to v2

### DIFF
--- a/include/copilot/types.hpp
+++ b/include/copilot/types.hpp
@@ -32,7 +32,7 @@ struct SessionEvent;
 // =============================================================================
 
 /// SDK protocol version - must match copilot-agent-runtime server
-inline constexpr int kSdkProtocolVersion = 1;
+inline constexpr int kSdkProtocolVersion = 2;
 
 // =============================================================================
 // Enums

--- a/tests/test_types.cpp
+++ b/tests/test_types.cpp
@@ -153,17 +153,17 @@ TEST(TypesTest, MessageOptions)
 
 TEST(TypesTest, PingResponse)
 {
-    json input = {{"message", "pong"}, {"timestamp", 1234567890}, {"protocolVersion", 1}};
+    json input = {{"message", "pong"}, {"timestamp", 1234567890}, {"protocolVersion", 2}};
 
     auto resp = input.get<PingResponse>();
     EXPECT_EQ(resp.message, "pong");
     EXPECT_EQ(resp.timestamp, 1234567890);
-    EXPECT_EQ(resp.protocol_version, 1);
+    EXPECT_EQ(resp.protocol_version, 2);
 }
 
 TEST(TypesTest, ProtocolVersion)
 {
-    EXPECT_EQ(kSdkProtocolVersion, 1);
+    EXPECT_EQ(kSdkProtocolVersion, 2);
 }
 
 TEST(TypesTest, SessionMetadataParsesIso8601Timestamps)


### PR DESCRIPTION
## Summary

Copilot CLI v0.0.394+ uses protocol version 2. This PR updates `kSdkProtocolVersion` from 1 to 2 to match.

Without this fix, the SDK throws:
```
SDK protocol version mismatch: SDK expects version 1, but server reports version 2
```

## Changes

- `include/copilot/types.hpp`: Update `kSdkProtocolVersion` to 2
- `tests/test_types.cpp`: Update test expectations

## Testing

- E2E tests pass with BYOK (35/38 passed, 2 skipped as expected for BYOK)
- Verified with z.ai GLM-4.7 endpoint