### PR TITLE
docs: use fluent tool builder syntax in README

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+byok.env


### PR DESCRIPTION
## Summary
- Replace verbose JSON schema construction with cleaner fluent API examples
- Lead with `ToolBuilder` for full control, then `make_tool()` for quick one-liners
- Auto-generated JSON schemas from C++ types - no more manual JSON!

## Before
```cpp
calc_tool.parameters_schema = copilot::json{
    {"type", "object"},
    {"properties", {{"expression", {{"type", "string"}}}}},
    {"required", {"expression"}}
};
```

## After
```cpp
auto calc = copilot::ToolBuilder("calculator", "Perform math calculations")
    .param<std::string>("expression", "Math expression to evaluate")
    .handler([](std::string expression) { return "42"; });
```

## Test plan
- [x] README snippets verified to compile and run