### PR TITLE
added skip permission from main sdk to port

### DIFF
--- a/include/copilot/types.hpp
+++ b/include/copilot/types.hpp
@@ -901,6 +901,23 @@ struct Tool
     std::string description;
     json parameters_schema;
     ToolHandler handler;
+
+    /// When true, this tool executes without triggering a permission prompt.
+    /// Use for read-only or otherwise safe tools.
+    bool skip_permission = false;
+
+    /// When true, allows this tool to replace a built-in CLI tool
+    /// (e.g. edit_file, read_file). Without this flag, registering a tool
+    /// with a built-in name will cause an error.
+    bool overrides_built_in_tool = false;
+
+    /// Fluent setter — mark this tool as not requiring permission prompts
+    Tool& with_skip_permission(bool value = true) & { skip_permission = value; return *this; }
+    Tool  with_skip_permission(bool value = true) && { skip_permission = value; return std::move(*this); }
+
+    /// Fluent setter — mark this tool as replacing a built-in CLI tool
+    Tool& with_overrides_built_in_tool(bool value = true) & { overrides_built_in_tool = value; return *this; }
+    Tool  with_overrides_built_in_tool(bool value = true) && { overrides_built_in_tool = value; return std::move(*this); }
 };
 
 // =============================================================================

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -56,6 +56,10 @@ json build_session_create_request(const SessionConfig& config)
             def["description"] = tool.description;
             if (!tool.parameters_schema.is_null())
                 def["parameters"] = tool.parameters_schema;
+            if (tool.skip_permission)
+                def["skipPermission"] = true;
+            if (tool.overrides_built_in_tool)
+                def["overridesBuiltInTool"] = true;
             tool_defs.push_back(def);
         }
         request["tools"] = tool_defs;
@@ -125,6 +129,10 @@ json build_session_resume_request(const std::string& session_id, const ResumeSes
             def["description"] = tool.description;
             if (!tool.parameters_schema.is_null())
                 def["parameters"] = tool.parameters_schema;
+            if (tool.skip_permission)
+                def["skipPermission"] = true;
+            if (tool.overrides_built_in_tool)
+                def["overridesBuiltInTool"] = true;
             tool_defs.push_back(def);
         }
         request["tools"] = tool_defs;


### PR DESCRIPTION
The official Python and TypeScript SDKs support `skip_permission` and `overrides_built_in_tool` on tool definitions ([Python docs](https://github.com/github/copilot-sdk/tree/main/python#skipping-permission-prompts)), but the C++ port doesn't include them yet. This PR adds parity for both.

## Changes

- **`include/copilot/types.hpp`** — Added `skip_permission` and `overrides_built_in_tool` bool fields to `struct Tool` (default `false`), plus ref-qualified fluent setters for chaining
- **`src/client.cpp`** — `build_session_create_request` and `build_session_resume_request` now include `skipPermission` and `overridesBuiltInTool` in the JSON-RPC tool payload when `true`

## Usage

```cpp
auto lookup = copilot::make_tool("safe_lookup", "Read-only lookup",
    [](std::string query) { return do_lookup(query); },
    {"query"}
).with_skip_permission();

auto editor = copilot::ToolBuilder("edit_file", "Custom editor")
    .param<std::string>("path", "File path")
    .handler([](std::string path) { /* ... */ })
    .with_overrides_built_in_tool();
```

Fully backward compatible — both fields default to `false`, no existing code affected.